### PR TITLE
Permanent statistic of jail ban

### DIFF
--- a/nethserver-fail2ban.spec
+++ b/nethserver-fail2ban.spec
@@ -39,6 +39,7 @@ rm -rf $RPM_BUILD_ROOT
 %{__mkdir_p} -p $RPM_BUILD_ROOT/var/run/fail2ban
 
 %{genfilelist} %{buildroot} \
+  --file /usr/libexec/nethserver/fail2ban-status 'attr(0755,root,root)' \
   --file /usr/bin/fail2ban-listban 'attr(0750,root,root)' \
   --file /usr/bin/fail2ban-unban 'attr(0750,root,root)' \
   --file /usr/libexec/nethserver/fail2ban-listban 'attr(0755,root,root)' \

--- a/root/usr/libexec/nethserver/fail2ban-status
+++ b/root/usr/libexec/nethserver/fail2ban-status
@@ -3,7 +3,7 @@ binmode STDOUT, ":utf8";
 use utf8;
 use JSON;
 
-my $jsonFile = '/var/lib/nethserver/db/fail2ban.json';
+my $jsonFile = '/var/lib/nethserver/fail2ban/fail2ban.json';
 my $json;
 
 if ( -f $jsonFile )    {

--- a/root/usr/libexec/nethserver/fail2ban-status
+++ b/root/usr/libexec/nethserver/fail2ban-status
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+binmode STDOUT, ":utf8";
+use utf8;
+use JSON;
+
+my $jsonFile = '/var/lib/nethserver/db/fail2ban.json';
+my $json;
+
+if ( -f $jsonFile )    {
+    open my $fh, "<", $jsonFile;
+    $json = <$fh>;
+    close $fh;
+    }
+else {
+    $json ='{"TotalBannedIP": {}}';
+    }
+
+print $json;

--- a/root/usr/libexec/nethserver/shorewall-nethserver
+++ b/root/usr/libexec/nethserver/shorewall-nethserver
@@ -6,6 +6,9 @@
 
 use esmith::ConfigDB;
 use esmith::DB;
+use utf8;
+use JSON;
+binmode STDOUT, ":utf8";
 
 my $fdb = esmith::ConfigDB->open('fail2ban')
     || esmith::ConfigDB->create('fail2ban');
@@ -25,10 +28,31 @@ my $date = localtime();
 
 if ($action eq 'drop') {
 
-    # Jail statistic
-    my $stat = $fdb->get_prop("jailStatistic",$jail) || 0;
-    $stat ++;
-    $fdb->set_prop("jailStatistic",$jail,$stat, type => 'stats');
+    # decode jsonFile
+    my $jsonFile = '/var/lib/nethserver/db/fail2ban.json';
+    my $json;
+
+    if ( -f $jsonFile )    {
+      open my $fh, "<", $jsonFile;
+      $json = <$fh>;
+      close $fh;
+    }
+    else {
+      $json ='{"TotalBannedIP": {}}';
+    }
+
+    my $data = decode_json($json);
+
+    # Retrieve the counter
+    my $counter = $data->{'TotalBannedIP'}{$jail} || 0;
+    $counter++;
+    $data->{'TotalBannedIP'}->{$jail}= $counter;
+
+    # Encode jsonFile
+    umask 022;
+    open my $fh, ">", $jsonFile;
+    print $fh encode_json($data);
+    close $fh;
 
     # Drop action
     $count = $fdb->get_prop("$ip",'counter');

--- a/root/usr/libexec/nethserver/shorewall-nethserver
+++ b/root/usr/libexec/nethserver/shorewall-nethserver
@@ -29,7 +29,7 @@ my $date = localtime();
 if ($action eq 'drop') {
 
     # decode jsonFile
-    my $jsonFile = '/var/lib/nethserver/db/fail2ban.json';
+    my $jsonFile = '/var/lib/nethserver/fail2ban/fail2ban.json';
     my $json;
 
     if ( -f $jsonFile )    {
@@ -38,6 +38,8 @@ if ($action eq 'drop') {
       close $fh;
     }
     else {
+      umask 022;
+      mkdir '/var/lib/nethserver/fail2ban';
       $json ='{"TotalBannedIP": {}}';
     }
 

--- a/root/usr/libexec/nethserver/shorewall-nethserver
+++ b/root/usr/libexec/nethserver/shorewall-nethserver
@@ -24,6 +24,13 @@ if ($count eq '') {
 my $date = localtime();
 
 if ($action eq 'drop') {
+
+    # Jail statistic
+    my $stat = $fdb->get_prop("jailStatistic",$jail) || 0;
+    $stat ++;
+    $fdb->set_prop("jailStatistic",$jail,$stat, type => 'stats');
+
+    # Drop action
     $count = $fdb->get_prop("$ip",'counter');
     $count ++;
     $fdb->set_prop("$ip",'counter',"$count");

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Dashboard_SystemStatus_Fail2ban.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Dashboard_SystemStatus_Fail2ban.php
@@ -1,0 +1,4 @@
+<?php
+$L['fail2banstatus_title'] = 'Fail2ban status';
+$L['TotalBannedIP_label'] = 'Total Banned IPs';
+$L['no_fail2ban_stat_label'] = 'There is no statistic';

--- a/root/usr/share/nethesis/NethServer/Module/Dashboard/SystemStatus/Fail2ban.php
+++ b/root/usr/share/nethesis/NethServer/Module/Dashboard/SystemStatus/Fail2ban.php
@@ -1,0 +1,52 @@
+<?php
+namespace NethServer\Module\Dashboard\SystemStatus;
+
+/*
+ * Copyright (C) 2018 Nethesis S.r.l.
+ *
+ * This script is part of NethServer.
+ *
+ * NethServer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NethServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Retrieve the total number of jails of jails
+ *
+ * @author Stephane de Labrusse <stephdl@de-labrusse.fr>
+ */
+class Fail2ban extends \Nethgui\Controller\AbstractController
+{
+
+    public $sortId = 10;
+ 
+    private $status = "";
+
+    private function readFail2banStatus()
+    {
+        return json_decode($this->getPlatform()->exec('/usr/libexec/nethserver/fail2ban-status')->getOutput(), true);
+    }
+
+    public function process()
+    {
+        $this->status = $this->readFail2banStatus();
+    }
+ 
+    public function prepareView(\Nethgui\View\ViewInterface $view)
+    {
+        if (!$this->status) {
+            $this->status = $this->readFail2banStatus();
+        }
+        $view['status'] = $this->status;
+    }
+}

--- a/root/usr/share/nethesis/NethServer/Template/Dashboard/SystemStatus/Fail2ban.php
+++ b/root/usr/share/nethesis/NethServer/Template/Dashboard/SystemStatus/Fail2ban.php
@@ -1,0 +1,18 @@
+<?php
+
+echo "<div class='dashboard-item'>";
+echo $view->header()->setAttribute('template',$T('fail2banstatus_title'));
+
+if ( ! file_exists ('/var/lib/nethserver/db/fail2ban.json')) {
+    echo $T('no_fail2ban_stat_label');
+    }
+else {
+    $totalCounter = 0;
+    foreach ($view['status']['TotalBannedIP'] as $key => $value) {
+        if (is_numeric ($value)){
+            $totalCounter = $totalCounter + $value;
+        }
+    }
+    echo '<br/>'.'<b>'.$T('TotalBannedIP').'</b>'." : $totalCounter";
+}
+

--- a/root/usr/share/nethesis/NethServer/Template/Dashboard/SystemStatus/Fail2ban.php
+++ b/root/usr/share/nethesis/NethServer/Template/Dashboard/SystemStatus/Fail2ban.php
@@ -13,6 +13,6 @@ else {
             $totalCounter = $totalCounter + $value;
         }
     }
-    echo '<br/>'.'<b>'.$T('TotalBannedIP').'</b>'." : $totalCounter";
+    echo '<br/>'.'<b>'.$T('TotalBannedIP_label').'</b>'." : $totalCounter";
 }
 

--- a/root/usr/share/nethesis/NethServer/Template/Dashboard/SystemStatus/Fail2ban.php
+++ b/root/usr/share/nethesis/NethServer/Template/Dashboard/SystemStatus/Fail2ban.php
@@ -3,7 +3,7 @@
 echo "<div class='dashboard-item'>";
 echo $view->header()->setAttribute('template',$T('fail2banstatus_title'));
 
-if ( ! file_exists ('/var/lib/nethserver/db/fail2ban.json')) {
+if ( ! file_exists ('/var/lib/nethserver/fail2ban/fail2ban.json')) {
     echo $T('no_fail2ban_stat_label');
     }
 else {


### PR DESCRIPTION
fail2ban logs the jail ban in a sqlite database which is reseted each time the service starts, I would like something we could monitor or store for ever

https://github.com/NethServer/dev/issues/5480