### PR TITLE
Always disable notification if Mail is set to disabled

### DIFF
--- a/root/etc/e-smith/templates/etc/fail2ban/action.d/sendmail-common.local/10all
+++ b/root/etc/e-smith/templates/etc/fail2ban/action.d/sendmail-common.local/10all
@@ -1,7 +1,7 @@
 {
 $OUT = '';
 
-if ($fail2ban{MailJailState} eq 'disabled') {
+if ($fail2ban{MailJailState} eq 'disabled' || $fail2ban{Mail} eq 'disabled') {
 $OUT .= qq(
 [Definition]
 


### PR DESCRIPTION
Make sure notifications are disabled even if 'MailJailState' is enabled,
but 'Mail' is disabled.

NethServer/dev#5586