### PR TITLE
postfix-sasl-abuse: catch usernames without @

### DIFF
--- a/root/etc/fail2ban/filter.d/postfix-sasl-abuse.conf
+++ b/root/etc/fail2ban/filter.d/postfix-sasl-abuse.conf
@@ -10,7 +10,7 @@ before = common.conf
 
 _daemon = postfix(-\w+)?/(?:submission/|smtps/)?smtp[ds]
 
-failregex = \[<HOST>\], sasl_method=(LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5), sasl_username=[^@]+@\S+$
+failregex = ^%(__prefix_line)s.*\[<HOST>\], sasl_method=(LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5), sasl_username=\S+$
 
 ignoreregex =
 


### PR DESCRIPTION
NethServer/dev/issues/5737
Also anchor regexp