### PR TITLE
Remove 'NethServer' from name

### DIFF
--- a/nethserver-fail2ban.json
+++ b/nethserver-fail2ban.json
@@ -1,6 +1,6 @@
 {
     "id": "nethserver-fail2ban",
-    "name": "NethServer Fail2ban",
+    "name": "Fail2ban",
     "summary": "Nethserver integration of Fail2ban",
     "description": "Nethserver integration of Fail2ban",
     "url": "",


### PR DESCRIPTION
Respect new naming policy.

As requested by @DavidePrincipi  in NethServer/dev#5745