### PR TITLE
Overwrite the default action for the asterisk jail

### DIFF
--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
@@ -5,6 +5,7 @@ return "\n#asterisk is not used on this server" unless (( -f '/var/log/asterisk/
 my $AsteriskAuth_status = $fail2ban{AsteriskAuth_status} || 'true';
 my $TCPPorts = $asterisk{TCPPorts} || '5060,6061';
 my $maxretry = $fail2ban{Asterisk_MaxRetry} || $fail2ban{MaxRetry}*2 || '6';
+my $action = (($fail2ban{Mail} || 'enabled') eq 'enabled') ? '%(action_mw)s' : '%(action_)s';
 
 $OUT .= qq (
 [asterisk]
@@ -12,11 +13,13 @@ enabled  = $AsteriskAuth_status
 port     = $TCPPorts
 logpath  = /var/log/asterisk/full
 maxretry = $maxretry
+action = $action
 
 [asterisk_nethserver]
 enabled  = $AsteriskAuth_status
 port     = $TCPPorts
 logpath  = /var/log/asterisk/full
 maxretry = $maxretry
+action = $action
 );
 }


### PR DESCRIPTION
The asterisk jail by default is set to send email when a ban occurs, we want to decide if we send email or not

https://github.com/NethServer/dev/issues/5829