### PR TITLE
Release all IP in shorewal dynamic

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -5,7 +5,8 @@ use esmith::Build::CreateLinks qw(:all);
 # actions to do
 my $event = 'nethserver-fail2ban-update';
 event_actions($event,
-             'initialize-default-databases' => '00');
+             'initialize-default-databases' => '00',
+             'nethserver-fail2ban-cleanShorewallDynamic' => '10');
 templates2events("/etc/fail2ban/fail2ban.local", $event);
 templates2events('/etc/fail2ban/action.d/sendmail-common.local', $event);
 templates2events('/etc/sudoers', $event);

--- a/root/etc/e-smith/events/actions/nethserver-fail2ban-cleanShorewallDynamic
+++ b/root/etc/e-smith/events/actions/nethserver-fail2ban-cleanShorewallDynamic
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# Whith the new fail2ban-0.10 we clean the dynamic zone because we use now ipset
+# This could be removed in the future version. if `IPList` is still in the json file
+# then fail2ban-statistics has not be triggered at least one time
+
+OUTPUT=$(/usr/bin/cat /var/lib/nethserver/fail2ban/fail2ban.json)
+if [[ $OUTPUT =~ 'IPList' ]]; then
+    /usr/sbin/iptables -F dynamic
+    /usr/sbin/shorewall save
+fi


### PR DESCRIPTION
With the move ipset for fail2ban, it possibly have some IP still banned in the dynamic zone of shorewall, we can release them safely, when fail2ban will restart, the logs will be inspected again and the relevant IP will be banned in ipset

https://github.com/NethServer/dev/issues/5943