### PR TITLE
Fix fail2ban010

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -21,9 +21,13 @@ event_actions($event, 'fail2ban-unban' => '10');
 # nethserver-fail2ban-save -> we need to expand/restart shorewall
 my $event = 'nethserver-fail2ban-save';
 event_actions($event,
-    'nethserver-fail2ban-unban-whitelist' => '10',
-    'nethserver-fail2ban-shorewall-event' => '90');
+    'nethserver-fail2ban-unban-whitelist' => '10');
 templates2events('/etc/fail2ban/action.d/sendmail-common.local', $event);
+templates2events('/etc/fail2ban/jail.local', $event);
+templates2events('/etc/shorewall/initdone', $event);
+templates2events('/etc/shorewall/blrules', $event);
+templates2events('/etc/shorewall/stopped', $event);
+event_services($event,'shorewall'=> 'restart');
 
 # Fail2ban services restart
 foreach my $event (qw ( nethserver-firewall-base-save )) {

--- a/nethserver-fail2ban.spec
+++ b/nethserver-fail2ban.spec
@@ -50,6 +50,7 @@ chmod +x %{buildroot}/usr/libexec/nethserver/api/%{name}/*
   --file /usr/libexec/nethserver/fail2ban-listban 'attr(0755,root,root)' \
   --file /usr/libexec/nethserver/fail2ban-listip 'attr(0755,root,root)' \
   --file /usr/libexec/nethserver/fail2ban-statistics 'attr(0750,root,root)' \
+  --file /usr/libexec/nethserver/fail2ban-ipset-destroy 'attr(0750,root,root)' \
   --file /etc/sudoers.d/50_nsapi_nethserver_fail2ban 'attr(0440,root,root)' \
 $RPM_BUILD_ROOT > e-smith-%{version}-filelist
 

--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10recidive
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10recidive
@@ -1,9 +1,9 @@
 {
     use NethServer::Fail2Ban;
-    my $bantime  = $fail2ban{BanTime}*336 || '604800';
-    my $perpetual  = $fail2ban{Recidive_Perpetual} || 'disabled';
-    $bantime  = '0' if ($perpetual eq 'enabled');
     my $findtime = '86400';
+    my $bantime  = '1209600';
+    my $perpetual  = $fail2ban{Recidive_Perpetual} || 'disabled';
+    $bantime  = '-1' if ($perpetual eq 'enabled');
     my $maxretry = $fail2ban{Recidive_MaxRetry} || $fail2ban{MaxRetry}*2 || '6';
     return ("\n#recidive not used on this server\n") if (! NethServer::Fail2Ban::listRecidiveJails());
 
@@ -12,7 +12,7 @@
         $OUT .= "enabled = true\n";
         $OUT .= "logpath = /var/log/fail2ban.log\n";
         $OUT .= "banaction = shorewall-ipset-proto6\n";
-        $OUT .= "bantime   = $bantime\n";
+        $OUT .= "bantime  = $bantime\n";
         $OUT .= "findtime  = $findtime\n";
         $OUT .= "maxretry = $maxretry\n\n";
     }

--- a/root/etc/e-smith/templates/etc/shorewall/blrules/20fail2ban
+++ b/root/etc/e-smith/templates/etc/shorewall/blrules/20fail2ban
@@ -1,6 +1,8 @@
 {
     # DROP the ipset jail in iptables
+    # No rules if status disabled
     use NethServer::Fail2Ban;
+    return "" if ($fail2ban{'status'} ne 'enabled');
     my $banLocal = $fail2ban{'BanLocalNetwork'} || 'disabled';
     foreach (NethServer::Fail2Ban::listAllJails()) {
         $OUT .= "DROP\tnet:+f2b-$_\tall\n";

--- a/root/etc/e-smith/templates/etc/shorewall/initdone/20fail2ban
+++ b/root/etc/e-smith/templates/etc/shorewall/initdone/20fail2ban
@@ -1,9 +1,18 @@
 {
     # create the ipset jail in iptables
     use NethServer::Fail2Ban;
+    my $bantime= $fail2ban{'BanTime'} || '1800';
+    my $perpetual = $fail2ban{'Recidive_Perpetual'} || 'disabled';
     foreach (NethServer::Fail2Ban::listAllJails()) {
-        $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-$_ hash:ip timeout 600 \");\n";
+    
+        if (($_ eq 'recidive') && ($perpetual eq 'enabled')) {
+            $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-recidive hash:ip timeout 0 \");\n";
+        } elsif ($_ eq 'recidive') {
+            # max ban time for ipset is 2147483 seconds
+            $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-recidive hash:ip timeout 1209600 \");\n";
+        } else {
+            $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-$_ hash:ip timeout $bantime \");\n";
+        }
     }
-
     $OUT .= '1;';
 }

--- a/root/etc/e-smith/templates/etc/shorewall/initdone/20fail2ban
+++ b/root/etc/e-smith/templates/etc/shorewall/initdone/20fail2ban
@@ -1,6 +1,8 @@
 {
     # create the ipset jail in iptables
+    # no rules if status disabled
     use NethServer::Fail2Ban;
+    return "" if ($fail2ban{'status'} ne 'enabled');
     my $bantime= $fail2ban{'BanTime'} || '1800';
     my $perpetual = $fail2ban{'Recidive_Perpetual'} || 'disabled';
     foreach (NethServer::Fail2Ban::listAllJails()) {

--- a/root/etc/e-smith/templates/etc/shorewall/stopped/20fail2ban
+++ b/root/etc/e-smith/templates/etc/shorewall/stopped/20fail2ban
@@ -1,0 +1,6 @@
+
+#
+# Fail2ban destroy all ipset when shorewall stop
+#
+
+/usr/libexec/nethserver/fail2ban-ipset-destroy

--- a/root/usr/libexec/nethserver/fail2ban-ipset-destroy
+++ b/root/usr/libexec/nethserver/fail2ban-ipset-destroy
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# destroy all f2b-X when shorewall stop
+
+for j in $(ipset -L -name | grep '^f2b')
+do
+    /usr/sbin/ipset  -quiet destroy $j
+done


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5943

we need to add a new script to destroy the ipset when shorewall stops, but `shorewall restart` does not exactly the same things than `systemctl restart shorewall`, IPSET complains that the set are still used by the kernel, so I need to use systemctl with `nethserver-fail2ban-save` when the sysadmin add or remove the jails.

Now we create the bantime with ipset on the fly, but we cannot have anymore a dynamic bantime for recidive because we are limited to `2147483` which is the maximum timeout of ipset. If you prefer we could set the recidive to the maximum, it is about 24 days