### PR TITLE
Remove backup of fail2ban sqlite database

### DIFF
--- a/UI-API.md
+++ b/UI-API.md
@@ -127,7 +127,6 @@ All available props to store in the fail2ban key of the esmith API
       "SogoAuth_status": "true",
       "Recidive_status": "true",
       "AsteriskAuth_status": "true",
-      "DbPurgeage": null,
       "Mail": "enabled",
       "MaxRetry": "3",
       "CustomDestemail": [],

--- a/api/read
+++ b/api/read
@@ -107,7 +107,6 @@ elsif ($cmd eq 'configuration') {
             AsteriskAuth_status => $db->get_prop('fail2ban','AsteriskAuth_status'),
             BanLocalNetwork => $db->get_prop('fail2ban','BanLocalNetwork'),
             BanTime => $db->get_prop('fail2ban','BanTime'),
-            DbPurgeage => $db->get_prop('fail2ban','DbPurgeage'),
             Dovecot_status => $db->get_prop('fail2ban','Dovecot_status'),
             EjabberAuth_status => $db->get_prop('fail2ban','EjabberAuth_status'),
             Mattermost_status => $db->get_prop('fail2ban','Mattermost_status'),

--- a/createlinks
+++ b/createlinks
@@ -6,6 +6,7 @@ use esmith::Build::CreateLinks qw(:all);
 my $event = 'nethserver-fail2ban-update';
 event_actions($event,
              'initialize-default-databases' => '00',
+             'nethserver-fail2ban-clean-sqlite-backup' => '01',
              'nethserver-fail2ban-cleanShorewallDynamic' => '10');
 templates2events("/etc/fail2ban/fail2ban.local", $event);
 templates2events('/etc/fail2ban/action.d/sendmail-common.local', $event);

--- a/root/etc/e-smith/events/actions/nethserver-fail2ban-clean-sqlite-backup
+++ b/root/etc/e-smith/events/actions/nethserver-fail2ban-clean-sqlite-backup
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# If we detect copies of the database, we can safely remove them
+
+/usr/bin/find /var/lib/fail2ban/ -type f -name fail2ban.sqlite3.????????\* -delete

--- a/root/etc/e-smith/templates/etc/fail2ban/fail2ban.local/10all
+++ b/root/etc/e-smith/templates/etc/fail2ban/fail2ban.local/10all
@@ -16,4 +16,4 @@ logtarget = /var/log/fail2ban.log
 # Options: dbpurgeage
 # Notes.: Sets age at which bans should be purged from the database
 # Values: [ SECONDS ] Default: 86400 (24hours)
-dbpurgeage = {($fail2ban{'DbPurgeage'} || '1209600');}
+dbpurgeage = 1209600


### PR DESCRIPTION
After a while we can find copy of sqlite database in /var/lib/fail2ban, this can take some rooms for several reasons


the goal of the PR is to clean the DB if we detect some copies of the db in `/var/lib/fail2ban`
```
-rw------- 1 root root 94635008 Jan 12  2020 fail2ban.sqlite3.20200112-212251
-rw------- 1 root root 39815168 Aug  3 16:27 fail2ban.sqlite3.20200803-142712
```

- remove the backup of the database
- set a static `DbPurgeage` to 1209600

https://github.com/NethServer/dev/issues/6285