### PR TITLE
Vacuum the sqlite database each month

### DIFF
--- a/nethserver-fail2ban.spec
+++ b/nethserver-fail2ban.spec
@@ -47,6 +47,7 @@ chmod +x %{buildroot}/usr/libexec/nethserver/api/%{name}/*
 %{genfilelist} %{buildroot} \
   --file /usr/libexec/nethserver/fail2ban-status 'attr(0755,root,root)' \
   --file /usr/bin/fail2ban-listban 'attr(0750,root,root)' \
+  --file /etc/cron.monthly/nethserver-fail2ban-vacuum 'attr(0750,root,root)' \
   --file /usr/bin/fail2ban-unban 'attr(0750,root,root)' \
   --file /usr/libexec/nethserver/fail2ban-listban 'attr(0755,root,root)' \
   --file /usr/libexec/nethserver/fail2ban-listip 'attr(0755,root,root)' \

--- a/root/etc/cron.monthly/nethserver-fail2ban-vacuum
+++ b/root/etc/cron.monthly/nethserver-fail2ban-vacuum
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Do a vacuum of the sqlite database of fail2ban each month
+# Test first if the db is not locked, else try 5 times.
+#
+
+for (( i=1; i<=5; i++ ))
+do
+    COMMAND=$(/usr/bin/sqlite3 /var/lib/fail2ban/fail2ban.sqlite3 "BEGIN EXCLUSIVE;COMMIT;" > /dev/null 2>&1 )
+    if [[ $? -eq 0 ]]; then
+        /usr/bin/sqlite3 /var/lib/fail2ban/fail2ban.sqlite3 "VACUUM;"
+        exit 0
+    else
+        sleep 5
+    fi
+done

--- a/root/etc/cron.monthly/nethserver-fail2ban-vacuum
+++ b/root/etc/cron.monthly/nethserver-fail2ban-vacuum
@@ -29,7 +29,7 @@ do
     COMMAND=$(/usr/bin/sqlite3 /var/lib/fail2ban/fail2ban.sqlite3 "BEGIN EXCLUSIVE;COMMIT;" > /dev/null 2>&1 )
     if [[ $? -eq 0 ]]; then
         /usr/bin/sqlite3 /var/lib/fail2ban/fail2ban.sqlite3 "VACUUM;"
-        exit 0
+        exit $?
     else
         sleep 5
     fi


### PR DESCRIPTION
We can improve the size of the sqlite database by doing a vacuum each month. It can improve really the speed because fail2ban remove the ban inside the db but sqlite does not reclaim the space itself.

To test the PR you can lock the db by

` sqlite3 /var/lib/fail2ban/fail2ban.sqlite3`

to lock
`BEGIN EXCLUSIVE;`
to unlock
`COMMIT;`

then trigger the script : `/etc/cron.monthly/nethserver-fail2ban-vacuum`

https://github.com/NethServer/dev/issues/6291