### PR TITLE
Remove backend validation for IP

### DIFF
--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/01localaccess
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/01localaccess
@@ -5,7 +5,6 @@
     # this list, as well as local networks.
     #---------------------------------------------------------------------
     use esmith::NetworksDB;
-    use Net::IPv4Addr qw(ipv4_chkip);
     my $ndb = esmith::NetworksDB->open_ro();
 
 #check the network to ignore
@@ -17,7 +16,7 @@
 #Add specific IP to ignore
     my @ip;
     foreach my $ip (split(/,/, ($fail2ban{IgnoreIP} || ""))) {
-    push @ip, $iptest if $iptest = ipv4_chkip($ip);
+    push @ip, $ip;
     #sort IP array
     %seen = ();
     @ip = sort (grep { ! $seen{ $_ }++ } (@ip));


### PR DESCRIPTION
The former backend validation of IP  removes the CIDR network and writes an IP

```
-    use Net::IPv4Addr qw(ipv4_chkip);
-    push @ip, $iptest if $iptest = ipv4_chkip($ip);
+    push @ip, $ip;
```

1.2.3.0/24 => 1.2.3.4

we do not need anymore this validation I needed it before when I started without backend

https://github.com/NethServer/dev/issues/6301