### PR TITLE
rspamd: support jail for standard http port

### DIFF
--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10rspamd
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10rspamd
@@ -11,4 +11,12 @@
         $OUT .= "logpath = /var/log/httpd-admin/access_log\n";
         $OUT .= "maxretry = $maxretry\n\n";
     }
+
+    foreach (NethServer::Fail2Ban::listRspamdJails()) {
+        $OUT .= "\n[$_]\n";
+        $OUT .= "enabled = true\n";
+        $OUT .= "port = 443\n";
+        $OUT .= "logpath = /var/log/httpd/access_log\n";
+        $OUT .= "maxretry = $maxretry\n\n";
+    }
 }


### PR DESCRIPTION
Support rspamd UI running on port 443

See NethServer/nethserver-mail#230

Nethserver/dev#6320