### PR TITLE
Revert "rspamd: support jail for standard http port"

### DIFF
--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10rspamd
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10rspamd
@@ -11,12 +11,4 @@
         $OUT .= "logpath = /var/log/httpd-admin/access_log\n";
         $OUT .= "maxretry = $maxretry\n\n";
     }
-
-    foreach (NethServer::Fail2Ban::listRspamdJails()) {
-        $OUT .= "\n[$_]\n";
-        $OUT .= "enabled = true\n";
-        $OUT .= "port = 443\n";
-        $OUT .= "logpath = /var/log/httpd/access_log\n";
-        $OUT .= "maxretry = $maxretry\n\n";
-    }
 }


### PR DESCRIPTION
This reverts commit b55dca9a30b19dadcbf890b324538b5f94bbff6c.

NethServer/dev#6344

See also NethServer/nethserver-mail#133