### PR TITLE
DEBUG loglevel is not provided anymore

### DIFF
--- a/api/validate
+++ b/api/validate
@@ -29,7 +29,7 @@ switch ($data['action']) {
 
     case "configuration":
         $v->declareParameter('BanLocalNetwork', Validate::SERVICESTATUS);
-        $v->declareParameter('LogLevel', $v->createValidator()->memberOf('CRITICAL','ERROR','WARNING','NOTICE','INFO','DEBUG'));
+        $v->declareParameter('LogLevel', $v->createValidator()->memberOf('CRITICAL','ERROR','WARNING','NOTICE','INFO'));
         $v->declareParameter('FindTime', Validate::POSITIVE_INTEGER);
         $v->declareParameter('BanTime', Validate::POSITIVE_INTEGER);
         $v->declareParameter('Mail', Validate::SERVICESTATUS);

--- a/createlinks
+++ b/createlinks
@@ -14,6 +14,7 @@ templates2events('/etc/sudoers', $event);
 
 # nethserver-firewall-base-save
 my $event = 'nethserver-firewall-base-save';
+templates2events("/etc/fail2ban/fail2ban.local", $event);
 templates2events('/etc/fail2ban/jail.local', $event);
 
 #Action to unbanIP

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -30,7 +30,6 @@
         "BanLocalNetwork": "Allow bans on the LAN",
         "LogLevel": "Logging Level",
         "LogLevel_INFO": "INFO",
-        "LogLevel_DEBUG": "DEBUG",
         "LogLevel_NOTICE": "NOTICE",
         "LogLevel_WARNING": "WARNING",
         "LogLevel_ERROR": "ERROR",
@@ -123,7 +122,7 @@
         "valid_memberOf_enabled, disabled": "Can be enabled or disabled",
         "valid_memberOf_true, false": "Can be true or false",
         "valid_integer": "Must be a positive integer",
-        "valid_memberOf_CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG": "Must be a member of CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG",
+        "valid_memberOf_CRITICAL, ERROR, WARNING, NOTICE, INFO": "Must be a member of CRITICAL, ERROR, WARNING, NOTICE, INFO",
         "0_0_0_0_network_is_prohibited": "The network 0.0.0.0/0 cannot be whitelisted: it is too wide."
     },
     "docs":{

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -235,7 +235,6 @@
               v-model="configuration.LogLevel"
               class="combobox form-control"
             >
-              <option value="DEBUG">{{$t('settings.LogLevel_DEBUG')}}</option>
               <option value="INFO">{{$t('settings.LogLevel_INFO')}}</option>
               <option value="NOTICE">{{$t('settings.LogLevel_NOTICE')}}</option>
               <option value="WARNING">{{$t('settings.LogLevel_WARNING')}}</option>


### PR DESCRIPTION
Debug can create a lot of logs, one customers who used DEBUG during a while got 600GB of fail2ban logs. Moreover it could beak also the recidive and lock out the sysadmin.

We do not provide anymore DEBUG, if enabled we go back to  INFO

https://github.com/NethServer/dev/issues/6470