### PR TITLE
New fail2ban  filter for webtop 

### DIFF
--- a/lib/perl/NethServer/Fail2Ban.pm
+++ b/lib/perl/NethServer/Fail2Ban.pm
@@ -88,7 +88,7 @@ sub listWebtopJails() {
     my $db = esmith::ConfigDB->open_ro();
     my $status = $db->get_prop('fail2ban', 'Webtop_status') || 'true';
 
-    if (( -f '/var/lib/tomcats/webtop/logs/localhost_access_log.txt') &&
+    if (( -f '/var/log/webtop/webtop_auth.log') &&
       ($status eq 'true')) {
         push(@jails, 'webtop');
     }

--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10webtop
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10webtop
@@ -8,7 +8,7 @@
         $OUT .= "\n[$_]\n";
         $OUT .= "enabled = true\n";
         $OUT .= "port = $port\n";
-        $OUT .= "logpath = //var/lib/tomcats/webtop/logs/localhost_access_log.txt\n";
+        $OUT .= "logpath = /var/log/webtop/webtop_auth.log\n";
         $OUT .= "maxretry = $maxretry\n\n";
     }
 }

--- a/root/etc/fail2ban/filter.d/webtop.conf
+++ b/root/etc/fail2ban/filter.d/webtop.conf
@@ -2,6 +2,9 @@
 #this filter is made against brute force attack to webtop
 # Author Stephane de Labrusse <stephdl@de-labrusse.fr>
 
-failregex = ^<HOST> - - \[*\] "POST /webtop/login HTTP/1.1" 200 \d+
+failregex = \[.*\]\s+\[.*\]\[.*\]\s+.*:\s+client=<HOST>\s+profile=.*\s+action=LOGIN_FAILURE$
 ignoreregex =
 
+
+# we need to match
+# 2021-04-14 18:20:27 [ERROR] [webtop][webtop:core] B0BD47CEFEEC54535A56859D0440FCB8: client=192.168.56.1 profile=stephane@NethServer action=LOGIN_FAILURE

--- a/root/etc/fail2ban/filter.d/webtop.conf
+++ b/root/etc/fail2ban/filter.d/webtop.conf
@@ -3,8 +3,10 @@
 # Author Stephane de Labrusse <stephdl@de-labrusse.fr>
 
 failregex = \[.*\]\s+\[.*\]\[.*\]\s+.*:\s+client=<HOST>\s+profile=.*\s+action=LOGIN_FAILURE$
+            \[.*\]\s+\[.*\]\[.*\]\s+.*:\s+client=<HOST>\s+profile=.*\s+action=OTP_FAILURE$
 ignoreregex =
 
 
 # we need to match
 # 2021-04-14 18:20:27 [ERROR] [webtop][webtop:core] B0BD47CEFEEC54535A56859D0440FCB8: client=192.168.56.1 profile=stephane@NethServer action=LOGIN_FAILURE
+# 2021-04-14 17:10:00 [ERROR] [webtop][webtop:core] 308AD412635D4B9A12CAC7C787367F29: client=192.168.56.1 profile=stephane@NethServer action=OTP_FAILURE


### PR DESCRIPTION
With The new version of webtop we have an authentication log, we can grep exactly the bad attempt

https://github.com/NethServer/dev/issues/6486