### PR TITLE
Accept FQDN for whitelist

### DIFF
--- a/api/validate
+++ b/api/validate
@@ -57,7 +57,6 @@ switch ($data['action']) {
             }
         }
 
-
         $emailValidator = $v->createValidator()->orValidator($v->createValidator(Validate::EMAIL), $v->createValidator(Validate::EMPTYSTRING));;
         foreach ($data['CustomDestemail'] as $el) {
             if (!$emailValidator->evaluate($el)) {

--- a/api/validate
+++ b/api/validate
@@ -43,14 +43,20 @@ switch ($data['action']) {
                 $v->createValidator(Validate::IPv4),
                 $v->createValidator(Validate::CIDR_BLOCK)
             );
+        $FQDNAllow = $v->createValidator(Validate::HOSTNAME_FQDN);
 
         foreach ( $data['IgnoreIP'] as $el) {
-            if (!$ipCidrAllow->evaluate($el) ) {
-                $v->addValidationError('IgnoreIP', 'not_a_valid_IP_or_CIDR', $el);
-            } elseif ($el === '0.0.0.0/0'){
+            if ($el === '0.0.0.0/0'){
                 $v->addValidationError('IgnoreIP', '0_0_0_0_network_is_prohibited', $el);
+            } elseif ($ipCidrAllow->evaluate($el)) {
+                continue;
+            } elseif ($FQDNAllow->evaluate($el)){
+                continue;
+            } else {
+                $v->addValidationError('IgnoreIP', 'not_a_valid_IP_or_CIDR_or_FQDN', $el);
             }
         }
+
 
         $emailValidator = $v->createValidator()->orValidator($v->createValidator(Validate::EMAIL), $v->createValidator(Validate::EMPTYSTRING));;
         foreach ($data['CustomDestemail'] as $el) {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -117,7 +117,7 @@
     },
     "validation":{
         "validation_failed": "Validation failed",
-        "not_a_valid_IP_or_CIDR_or_FQDN": "It must be a IPv4 address like '1.2.3.4', a CIDR network like '192.168.1.0/24' or a domain name like 'my.domain.com'",
+        "not_a_valid_IP_or_CIDR_or_FQDN": "It must be a IPv4 address like '1.2.3.4', a CIDR network like '192.168.1.0/24' or a fully qualified domain name like 'my.domain.com'",
         "not_valid_email_address": "Invalid mail address: it should be something like 'myname@domain.com'",
         "valid_memberOf_enabled, disabled": "Can be enabled or disabled",
         "valid_memberOf_true, false": "Can be true or false",
@@ -128,7 +128,7 @@
     "docs":{
         "fail2ban": "Fail2ban",
         "more_info_about": "More Information about ",
-        "IgnoreIP": "All IP (1.2.3.4), CIDR network (192.168.1.0/24) or domain name (my.domain.com) in this list will never be banned by Fail2ban. Add one entry per line",
+        "IgnoreIP": "All IP (1.2.3.4), CIDR network (192.168.1.0/24) or a fully qualified domain name (my.domain.com) in this list will never be banned by Fail2ban. Add one entry per line",
         "MailJailState": "All relative events to the jail (start or stop), will be notified to root and other recipients",
         "FindTime": "When fail2ban starts, the service looks for attackers in the logs for this time interval",
         "LogLevel": "The DEBUG level could generate huge log size and fill your disk space",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -117,7 +117,7 @@
     },
     "validation":{
         "validation_failed": "Validation failed",
-        "not_a_valid_IP_or_CIDR": "It must be a IPv4 address like '1.2.3.4' or a CIDR network like '192.168.1.0/24'",
+        "not_a_valid_IP_or_CIDR_or_FQDN": "It must be a IPv4 address like '1.2.3.4', a CIDR network like '192.168.1.0/24' or a domain name like 'my.domain.com'",
         "not_valid_email_address": "Invalid mail address: it should be something like 'myname@domain.com'",
         "valid_memberOf_enabled, disabled": "Can be enabled or disabled",
         "valid_memberOf_true, false": "Can be true or false",
@@ -128,7 +128,7 @@
     "docs":{
         "fail2ban": "Fail2ban",
         "more_info_about": "More Information about ",
-        "IgnoreIP": "All IP (1.2.3.4) or CIDR network (192.168.1.0/24) in this list will never be banned by Fail2ban. Add one entry per line",
+        "IgnoreIP": "All IP (1.2.3.4), CIDR network (192.168.1.0/24) or domain name (my.domain.com) in this list will never be banned by Fail2ban. Add one entry per line",
         "MailJailState": "All relative events to the jail (start or stop), will be notified to root and other recipients",
         "FindTime": "When fail2ban starts, the service looks for attackers in the logs for this time interval",
         "LogLevel": "The DEBUG level could generate huge log size and fill your disk space",


### PR DESCRIPTION
We can accept FQDN/Domain name for whitelisting, when you do not have a static IP it can help you to not be locked out.

https://github.com/NethServer/dev/issues/6491