### PR TITLE
UI: improve whitelist label

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -22,7 +22,7 @@
         "title": "Settings",
         "configuration": "Configuration",
         "status": "Enable the service",
-        "IgnoreIP": "IP Whitelist",
+        "IgnoreIP": "Whitelist",
         "mail": "Email notifications",
         "notify_to": "Notify to",
         "add_email": "Add an email",


### PR DESCRIPTION
The whitelist field now accepts also FQDNs not only IPs.

NethServer/dev#6491