### PR TITLE
conf: merge asterisk jail into asterisk_nethserver

### DIFF
--- a/lib/perl/NethServer/Fail2Ban.pm
+++ b/lib/perl/NethServer/Fail2Ban.pm
@@ -320,7 +320,7 @@ sub listAsteriskJails {
     my $status = $db->get_prop('fail2ban', 'AsteriskAuth_status') || 'true';
 
     if ( -f '/var/log/asterisk/full') {
-        foreach (qw( asterisk asterisk_nethserver )) {
+        foreach (qw( asterisk_nethserver )) {
             if (($status eq 'true') && ($asterisk eq 'enabled')){
                 push(@jails, $_);
             }

--- a/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
+++ b/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
@@ -22,5 +22,14 @@ failregex =  ^%(__prefix_line)s%(log_prefix)s <HOST> failed to authenticate as '
              ^%(__prefix_line)s%(log_prefix)s <HOST> tried to authenticate with nonexistent user '.*'$
              ^%(__prefix_line)s%(log_prefix)s <HOST> failed to pass IP ACL as '.*'$
              ^%(__prefix_line)s%(log_prefix)s "Rejecting unknown SIP connection from <HOST>:.*"$
+             ^%(__prefix_line)s%(log_prefix)s Registration from '[^']*' failed for '<HOST>(:\d+)?' - (?:Wrong password|Username/auth name mismatch|No matching peer found|Not a local domain|Device does not match ACL|Peer is not supposed to register|ACL error \(permit/deny\)|Not a local domain)$
+             ^%(__prefix_line)s%(log_prefix)s Call from '[^']*' \(<HOST>:\d+\) to extension '[^']*' rejected because extension not found in context
+             ^%(__prefix_line)s%(log_prefix)s (?:Host )?<HOST> (?:failed (?:to authenticate\b|MD5 authentication\b)|tried to authenticate with nonexistent user\b)
+             ^%(__prefix_line)s%(log_prefix)s No registration for peer '[^']*' \(from <HOST>\)$
+             ^%(__prefix_line)s%(log_prefix)s hacking attempt detected '<HOST>'$
+             ^%(__prefix_line)s%(log_prefix)s SecurityEvent="(?:FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)"(?:(?:,(?!RemoteAddress=)\w+="[^"]*")*|.*?),RemoteAddress="IPV[46]/[^/"]+/<HOST>/\d+"(?:,(?!RemoteAddress=)\w+="[^"]*")*$
+             ^%(__prefix_line)s%(log_prefix)s "Rejecting unknown SIP connection from <HOST>(?::\d+)?"$
+             ^%(__prefix_line)s%(log_prefix)s Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:No matching endpoint found|Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\s*$
+
 
 ignoreregex =


### PR DESCRIPTION
The asterisk jail uses asterisk-udp and asterisk-tcp ipsets,
but those ipsets are not listed inside /etc/shorewall/blrules

NethServer/dev#6605