### PR TITLE
shorewall: make sure asterisk ipset are ready

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/initdone/20fail2ban
+++ b/root/etc/e-smith/templates/etc/shorewall/initdone/20fail2ban
@@ -8,6 +8,9 @@
         if ($_ eq 'recidive') {
             # max ban time for ipset is 2147483 seconds
             $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-recidive hash:ip timeout 1209600 \");\n";
+        } elsif ($_ eq 'asterisk') {
+            $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-$_-tcp hash:ip timeout $bantime \");\n";
+            $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-$_-udp hash:ip timeout $bantime \");\n";
         } else {
             $OUT .= "system(\"/usr/sbin/ipset -quiet -exist create f2b-$_ hash:ip timeout $bantime \");\n";
         }


### PR DESCRIPTION
If the ipset are not created, shorewall may fail at boot with:
```
shorewall[989]: WARNING: Ipset f2b-asterisk-tcp does not exist /etc/shorewall/blrules (line 30)
shorewall[989]: WARNING: Ipset f2b-asterisk-udp does not exist /etc/shorewall/blrules (line 31)
```

NethServer/dev#6608