### PR TITLE
Enhance fail2ban configuration for Asterisk

### DIFF
--- a/prep-sources
+++ b/prep-sources
@@ -1,9 +1,17 @@
 #!/bin/bash
 
-# Prepare source for RPM build
+#
+# Build  NS7 UI
+#
 
-# download langs from transifex
+set -e
 
-# tar directory
-pushd ui && npm install && npm run build && cd dist && tar cvzf ../../nethserver-fail2ban-cockpit.tar.gz *
+# Build UI
+NODE_OPTIONS="--openssl-legacy-provider"
+export NODE_OPTIONS
+pushd ui
+npm install
+npm run build
 popd
+
+tar -C ui/dist -c -z -f nethserver-fail2ban-cockpit.tar.gz .

--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
@@ -9,7 +9,7 @@
         $OUT .= "\n[$_]\n";
         $OUT .= "enabled = true\n";
         $OUT .= "port = $port\n";
-        $OUT .= "logpath = /var/log/asterisk/full\n";
+        $OUT .= "logpath = /var/log/asterisk/full /var/log/asterisk/nethcti.log\n";
         $OUT .= "maxretry = $maxretry\n";
         $OUT .= "action = $action\n\n"
 

--- a/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
+++ b/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
@@ -22,5 +22,6 @@ failregex =  ^%(__prefix_line)s%(log_prefix)s <HOST> failed to authenticate as '
              ^%(__prefix_line)s%(log_prefix)s <HOST> tried to authenticate with nonexistent user '.*'$
              ^%(__prefix_line)s%(log_prefix)s <HOST> failed to pass IP ACL as '.*'$
              ^%(__prefix_line)s%(log_prefix)s "Rejecting unknown SIP connection from <HOST>:.*"$
+             ^%(__prefix_line)s *.send HTTP 401 response to <HOST>:.*$
 
 ignoreregex =


### PR DESCRIPTION
Improve fail2ban settings by adding a new log path and failregex to capture CTI HTTP 401 responses.