### PR TITLE
Update Asterisk jail configuration for fail2ban

### DIFF
--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
@@ -9,7 +9,7 @@
         $OUT .= "\n[$_]\n";
         $OUT .= "enabled = true\n";
         $OUT .= "port = $port\n";
-        $OUT .= "logpath = /var/log/asterisk/full /var/log/asterisk/nethcti.log\n";
+        $OUT .= "logpath = /var/log/asterisk/full\n /var/log/asterisk/nethcti.log\n";
         $OUT .= "maxretry = $maxretry\n";
         $OUT .= "action = $action\n\n"
 

--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10asterisk
@@ -9,7 +9,7 @@
         $OUT .= "\n[$_]\n";
         $OUT .= "enabled = true\n";
         $OUT .= "port = $port\n";
-        $OUT .= "logpath = /var/log/asterisk/full\n";
+        $OUT .= "logpath = /var/log/asterisk/full /var/log/asterisk/nethcti.log\n";
         $OUT .= "maxretry = $maxretry\n";
         $OUT .= "action = $action\n\n"
 

--- a/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
+++ b/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
@@ -22,6 +22,6 @@ failregex =  ^%(__prefix_line)s%(log_prefix)s <HOST> failed to authenticate as '
              ^%(__prefix_line)s%(log_prefix)s <HOST> tried to authenticate with nonexistent user '.*'$
              ^%(__prefix_line)s%(log_prefix)s <HOST> failed to pass IP ACL as '.*'$
              ^%(__prefix_line)s%(log_prefix)s "Rejecting unknown SIP connection from <HOST>:.*"$
-             ^%(__prefix_line)s *.send HTTP 401 response to <HOST>:.*$
+             send HTTP 401 response to <HOST>:\d+$
 
 ignoreregex =

--- a/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
+++ b/root/etc/fail2ban/filter.d/asterisk_nethserver.conf
@@ -22,5 +22,6 @@ failregex =  ^%(__prefix_line)s%(log_prefix)s <HOST> failed to authenticate as '
              ^%(__prefix_line)s%(log_prefix)s <HOST> tried to authenticate with nonexistent user '.*'$
              ^%(__prefix_line)s%(log_prefix)s <HOST> failed to pass IP ACL as '.*'$
              ^%(__prefix_line)s%(log_prefix)s "Rejecting unknown SIP connection from <HOST>:.*"$
+             ^%(__prefix_line)s *.send HTTP 401 response to <HOST>:.*$
 
 ignoreregex =


### PR DESCRIPTION
Enhance the Asterisk jail configuration by adding an additional log path and updating the regex to improve log monitoring.